### PR TITLE
Added version info and KSPAssembly call

### DIFF
--- a/src/Properties/AssemblyInfo.cs
+++ b/src/Properties/AssemblyInfo.cs
@@ -33,4 +33,6 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("0.9.7.2")]
+[assembly: AssemblyInformationalVersion("0.9.7.2")]
+[assembly: KSPAssembly("KerbalKonstructs", 0, 9)]


### PR DESCRIPTION
I'm integrating @alphaash's [KerKonConConExt](https://github.com/AlphaAsh/KerKonConConExt) directly into Contract Configurator, and one issue I have is that I don't want it to load if Kerbal Konstructs is not present.  I can do that with a KSPAssemblyDependency, but only if the target mod has a KSPAssembly (which Kerbal Konstructs does not).

Long story short: here's a pull request to make my life easier. :wink: 